### PR TITLE
Proposed updates to fix the outdated parts in the code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,16 @@ CFLAGS ?= -O5
 # have_inline defined for gsl to use extern inline functions when possible:
 CXXFLAGS ?= -O5 -DHAVE_INLINE $(OSDEFS)
 
-TARGET = wsflux
+TARGETS = weight_int wsflux
 
 INCLUDES = *.H
 # INCLUDES = io.H multipoly.H eam.H
 
 .PHONY: all clean archive
 
-all: $(TARGET)
+all: $(TARGETS)
+
+weight_int:	weight_int.C $(INCLUDES)
 
 wslux:	wsflux.C $(INCLUDES)
 

--- a/chgcar.H
+++ b/chgcar.H
@@ -199,10 +199,25 @@ void read_CHGCAR_header(FILE* infile, char* comment, double& a0,
     sscanf(dump, "%lf %lf %lf", latt+i, latt+3+i, latt+6+i);
   }
 
-  //++ number of atoms
+  /*
+  * In VASP 5 or later versions one should see a line of text specifying the element names here
+  * whereas in older versions no such line exists, but atom numbers are written here.
+  * I modified Dallas's original code so that it works with both versions. --Yang
+  */
   fgets(dump, sizeof(dump), infile);
   char *strp, *endp=dump;
   int types = 0, Natoms=0;
+
+  // check to see if this line is a list of element names or atom numbers
+  strp = endp;
+  i = strtol(strp, &endp, 10);
+  if (endp == strp) { // skip the current line and read the next line if we see a list of element names
+    fgets(dump, sizeof(dump), infile);
+  }
+  endp = dump;
+  // Modification ends here. --Yang
+
+  //++ number of atoms
   if (READATOMS && (Natom==NULL)) Natom=new int[128];
   do {
     strp=endp;
@@ -249,13 +264,28 @@ void skip_CHGCAR_header(FILE* infile)
   //++ lattice vectors
   for (int i=0; i<3; ++i) fgets(dump, sizeof(dump), infile);
 
-  //++ number of atoms
+  /*
+  * In VASP 5 or later versions one should see a line of text specifying the element names here
+  * whereas in older versions no such line exists, but atom numbers are written here.
+  * I modified Dallas's original code so that it works with both versions. --Yang
+  */
   fgets(dump, sizeof(dump), infile);
   char *strp, *endp=dump;
   int Natoms=0;
+
+  // check to see if this line is a list of element names or atom numbers
+  strp = endp;
+  int i = strtol(strp, &endp, 10);
+  if (endp == strp) { // skip the current line and read the next line if we see a list of element names
+    fgets(dump, sizeof(dump), infile);
+  }
+  endp = dump;
+  // Modification ends here. --Yang
+
+  //++ number of atoms
   do {
     strp=endp;
-    int i = strtol(strp, &endp, 10);
+    i = strtol(strp, &endp, 10);
     if (strp!=endp) Natoms += i;
   } while (strp!=endp);
 

--- a/chgcar.H
+++ b/chgcar.H
@@ -40,10 +40,10 @@ void read_grid(FILE* infile, double* rho, int Ng)
   if (infile==NULL) return;
 
   int n, line, nl;
-  char dump[512];
+  char dump[512], *p_fgets;
 
   if (Ng == 0) {
-    fgets(dump, sizeof(dump), infile);
+    p_fgets = fgets(dump, sizeof(dump), infile);
     return;
   }
 
@@ -51,14 +51,14 @@ void read_grid(FILE* infile, double* rho, int Ng)
   n=0;
   
   for (line=0, n=0; line<nl; ++line, n+=READ_stride) {
-    fgets(dump, sizeof(dump), infile);
+    p_fgets = fgets(dump, sizeof(dump), infile);
     sscanf(dump, "%lf %lf %lf %lf %lf",
 	   rho+n, rho+n+1, rho+n+2, rho+n+3, rho+n+4);
   }
 
   if (n!=Ng) {
     // last line...
-    fgets(dump, sizeof(dump), infile);
+    p_fgets = fgets(dump, sizeof(dump), infile);
     char *strp, *endp;
     for (strp=dump; n<Ng; ++n, strp=endp)
       rho[n] = strtod(strp, &endp);
@@ -73,10 +73,10 @@ void read_grid(FILE* infile, double* rho, int Ng, int* index)
   if (infile==NULL) return;
 
   int n, line, nl;
-  char dump[512];
+  char dump[512], *p_fgets;
 
   if (Ng == 0) {
-    fgets(dump, sizeof(dump), infile);
+    p_fgets = fgets(dump, sizeof(dump), infile);
     return;
   }
 
@@ -84,14 +84,14 @@ void read_grid(FILE* infile, double* rho, int Ng, int* index)
   n=0;
   
   for (line=0, n=0; line<nl; ++line, n+=READ_stride) {
-    fgets(dump, sizeof(dump), infile);
+    p_fgets = fgets(dump, sizeof(dump), infile);
     sscanf(dump, "%lf %lf %lf %lf %lf",
 	   rho+index[n], rho+index[n+1], rho+index[n+2], rho+index[n+3], rho+index[n+4]);
   }
 
   if (n!=Ng) {
     // last line...
-    fgets(dump, sizeof(dump), infile);
+    p_fgets = fgets(dump, sizeof(dump), infile);
     char *strp, *endp;
     for (strp=dump; n<Ng; ++n, strp=endp)
       rho[index[n]] = strtod(strp, &endp);
@@ -110,7 +110,7 @@ void fort_printf(char* str, const double& x)
   if (x >= 0) str[0] = '0';
   // fix the exponent (only if non-zero)
   if (x != 0) {
-    int expon = strtol(str+14, (char**)NULL, 10);
+    int expon = (int)strtol(str+14, (char**)NULL, 10);
     expon++;
     if (expon>=0) str[14] = '+';
     else         {str[14] = '-'; expon = -expon;}
@@ -131,7 +131,7 @@ void write_grid(FILE* outfile, double* rho, int Ng)
     return;
   }
   int n;
-  char dump[18];
+  char dump[28];
   for (n=0; n<Ng; ++n) {
     fort_printf(dump, rho[n]);
     fprintf(outfile, " %s", dump);
@@ -150,7 +150,7 @@ void write_grid(FILE* outfile, double* rho, int Ng, int* index)
     return;
   }
   int n;
-  char dump[18];
+  char dump[28];
   for (n=0; n<Ng; ++n) {
     fort_printf(dump, rho[index[n]]);
     fprintf(outfile, " %s", dump);
@@ -180,22 +180,22 @@ void read_CHGCAR_header(FILE* infile, char* comment, double& a0,
 {
   if (infile==NULL) return;
 
-  char dump[512];
+  char dump[512], *p_fgets;
   int i;
 
   //++ comment line
-  fgets(dump, sizeof(dump), infile);
+  p_fgets = fgets(dump, sizeof(dump), infile);
   char *p = 
     stpcpy(comment, dump);
   (p-1)[0] = '\0'; // remove the newline at the end of dump.
 
   //++ a0
-  fgets(dump, sizeof(dump), infile);
+  p_fgets = fgets(dump, sizeof(dump), infile);
   sscanf(dump, "%lf", &a0);
 
   //++ lattice vectors
   for (i=0; i<3; ++i) {
-    fgets(dump, sizeof(dump), infile);
+    p_fgets = fgets(dump, sizeof(dump), infile);
     sscanf(dump, "%lf %lf %lf", latt+i, latt+3+i, latt+6+i);
   }
 
@@ -204,15 +204,15 @@ void read_CHGCAR_header(FILE* infile, char* comment, double& a0,
   * whereas in older versions no such line exists, but atom numbers are written here.
   * I modified Dallas's original code so that it works with both versions. --Yang
   */
-  fgets(dump, sizeof(dump), infile);
+  p_fgets = fgets(dump, sizeof(dump), infile);
   char *strp, *endp=dump;
   int types = 0, Natoms=0;
 
   // check to see if this line is a list of element names or atom numbers
   strp = endp;
-  i = strtol(strp, &endp, 10);
+  i = (int)strtol(strp, &endp, 10);
   if (endp == strp) { // skip the current line and read the next line if we see a list of element names
-    fgets(dump, sizeof(dump), infile);
+    p_fgets = fgets(dump, sizeof(dump), infile);
   }
   endp = dump;
   // Modification ends here. --Yang
@@ -221,7 +221,7 @@ void read_CHGCAR_header(FILE* infile, char* comment, double& a0,
   if (READATOMS && (Natom==NULL)) Natom=new int[128];
   do {
     strp=endp;
-    i = strtol(strp, &endp, 10);
+    i = (int)strtol(strp, &endp, 10);
     if (strp!=endp) {
       Natoms += i;
       if (READATOMS) Natom[types] = i;
@@ -231,12 +231,12 @@ void read_CHGCAR_header(FILE* infile, char* comment, double& a0,
   if (READATOMS) Natom[types] = -1;
 
   //++ direct coord. (CHGCAR should always be output with "Direct")
-  fgets(dump, sizeof(dump), infile);
+  p_fgets = fgets(dump, sizeof(dump), infile);
 
   //++ atom positions
   if (READATOMS) uatom = new double*[Natoms];
   for (i=0; i<Natoms; ++i) {
-    fgets(dump, sizeof(dump), infile);
+    p_fgets = fgets(dump, sizeof(dump), infile);
     if (READATOMS) {
       uatom[i] = new double[3];
       double* in_vect = uatom[i];
@@ -245,7 +245,7 @@ void read_CHGCAR_header(FILE* infile, char* comment, double& a0,
   }
   
   //++ blank line
-  fgets(dump, sizeof(dump), infile);
+  p_fgets = fgets(dump, sizeof(dump), infile);
 }
 
 
@@ -253,31 +253,31 @@ void skip_CHGCAR_header(FILE* infile)
 {
   if (infile==NULL) return;
 
-  char dump[512];
+  char dump[512], *p_fgets;
 
   //++ comment line
-  fgets(dump, sizeof(dump), infile);
+  p_fgets = fgets(dump, sizeof(dump), infile);
 
   //++ a0
-  fgets(dump, sizeof(dump), infile);
+  p_fgets = fgets(dump, sizeof(dump), infile);
 
   //++ lattice vectors
-  for (int i=0; i<3; ++i) fgets(dump, sizeof(dump), infile);
+  for (int i=0; i<3; ++i) p_fgets = fgets(dump, sizeof(dump), infile);
 
   /*
   * In VASP 5 or later versions one should see a line of text specifying the element names here
   * whereas in older versions no such line exists, but atom numbers are written here.
   * I modified Dallas's original code so that it works with both versions. --Yang
   */
-  fgets(dump, sizeof(dump), infile);
+  p_fgets = fgets(dump, sizeof(dump), infile);
   char *strp, *endp=dump;
   int Natoms=0;
 
   // check to see if this line is a list of element names or atom numbers
   strp = endp;
-  int i = strtol(strp, &endp, 10);
+  int i = (int)strtol(strp, &endp, 10);
   if (endp == strp) { // skip the current line and read the next line if we see a list of element names
-    fgets(dump, sizeof(dump), infile);
+    p_fgets = fgets(dump, sizeof(dump), infile);
   }
   endp = dump;
   // Modification ends here. --Yang
@@ -285,19 +285,19 @@ void skip_CHGCAR_header(FILE* infile)
   //++ number of atoms
   do {
     strp=endp;
-    i = strtol(strp, &endp, 10);
+    i = (int)strtol(strp, &endp, 10);
     if (strp!=endp) Natoms += i;
   } while (strp!=endp);
 
   //++ direct coord. (CHGCAR should always be output with "Direct")
-  fgets(dump, sizeof(dump), infile);
+  p_fgets = fgets(dump, sizeof(dump), infile);
 
   //++ atom positions
   for (int i=0; i<Natoms; ++i) 
-    fgets(dump, sizeof(dump), infile);
+    p_fgets = fgets(dump, sizeof(dump), infile);
   
   //++ blank line
-  fgets(dump, sizeof(dump), infile);
+  p_fgets = fgets(dump, sizeof(dump), infile);
 }
 
 

--- a/weight_int.C
+++ b/weight_int.C
@@ -235,7 +235,7 @@ int main ( int argc, char **argv )
   if (TESTING) fprintf(stderr, "## reading %s\n", infile_name);
 
   // parse that file...
-  char dump[512];
+  char dump[600];
   char comment[512];
   double a0, alatt[9], gridlatt[9], metric[9];
   

--- a/weight_int.C
+++ b/weight_int.C
@@ -154,7 +154,7 @@ int main ( int argc, char **argv )
   char* OUTBASE = NULL;	// basename for output
   
   char ch;
-  while ((ch = getopt(argc, argv, "Vaso:n:hvtm:")) != -1) {
+  while ((ch = (char)getopt(argc, argv, "Vaso:n:hvtm:")) != -1) {
     switch (ch) {
     case 'V':
       VORONOI = 1;
@@ -248,7 +248,7 @@ int main ( int argc, char **argv )
   for (int d=0; d<9; ++d) metric[d] *= a0*a0;
   int Natoms=0;
   for (int nt=0; Natom[nt]>=0; ++nt) Natoms += Natom[nt];
-  fgets(dump, sizeof(dump), infile);
+  char *p_fgets = fgets(dump, sizeof(dump), infile);
   sscanf(dump, "%d %d %d", Ngrid, Ngrid+1, Ngrid+2);
 
   if (TESTING) {
@@ -338,7 +338,7 @@ int main ( int argc, char **argv )
       continue;
     }
     skip_CHGCAR_header(infile);
-    fgets(dump, sizeof(dump), infile);
+    p_fgets = fgets(dump, sizeof(dump), infile);
     int Ntemp[3];
     sscanf(dump, "%d %d %d", Ntemp, Ntemp+1, Ntemp+2);
     if ( (Ngrid[0] != Ntemp[0]) ||

--- a/wsflux.C
+++ b/wsflux.C
@@ -57,7 +57,7 @@ const char COMMENT_CHAR = '#';
 const char EOF_CHAR = '&';
 
 inline void nextnoncomment (FILE* infile, char* dump, const int &size) 
-{ do {fgets(dump, size, infile);} 
+{ do {char *p_fgets = fgets(dump, size, infile);} 
   while ((!feof(infile)) && (dump[0] == COMMENT_CHAR)); }
 
 
@@ -110,7 +110,7 @@ int main ( int argc, char **argv )
   int MEMORY = 128;  // Our default storage (not used)
   
   char ch;
-  while ((ch = getopt(argc, argv, "hvtm:")) != -1) {
+  while ((ch = (char)getopt(argc, argv, "hvtm:")) != -1) {
     switch (ch) {
     case 'm':
       MEMORY = (int)strtol(optarg, (char**)NULL, 10);
@@ -156,12 +156,12 @@ int main ( int argc, char **argv )
   if (ERROR) exit(ERROR);
 
   // parse that file...
-  char dump[512];
+  char dump[512], *p_fgets;
   double a0, alatt[9];
   int Ngrid[3];
 
   read_CHGCAR_header(infile, dump, a0, alatt);
-  fgets(dump, sizeof(dump), infile);
+  p_fgets = fgets(dump, sizeof(dump), infile);
   sscanf(dump, "%d %d %d", Ngrid, Ngrid+1, Ngrid+2);
 
   if (TESTING) {


### PR DESCRIPTION
This proposed update tries to fix the follow two issues:

1. Failure to read charge density files formatted according to the CHGCAR format in VASP 5 or newer, which adds a new line to the header specifying the ion species. The updated file `chgcar.H` will check if such line exists and will skip it if necessary, adapting the Bader Integration code to work with both old and new CHGCAR formats.
2. Warnings raised by the current GCC compilers. Minor updates are done to address these warnings, which mainly involve ignored return values, unmatched data types, or concerns over array sizes, etc. The updates are done and tested using GCC 13.